### PR TITLE
Rename get_node for PyTables 3.x dependency

### DIFF
--- a/policyopt/nn.py
+++ b/policyopt/nn.py
@@ -390,7 +390,7 @@ class TrainingLog(object):
             self.f.create_array(groupname, arrayname, v.get_value(), createparents=True)
 
         # Store the model hash as an attribute
-        self.f.getNode(snapshot_root)._v_attrs.hash = model.savehash()
+        self.f.get_node(snapshot_root)._v_attrs.hash = model.savehash()
 
         self.f.flush()
 


### PR DESCRIPTION
Running the script in train phase will give me following error:

File "[localpath]/imitation/policyopt/nn.py", line 393, in write_snapshot
    self.f.getNode(snapshot_root)._v_attrs.hash = model.savehash()
AttributeError: 'File' object has no attribute 'getNode'

That's because PyTables changed some of its API for 3.x

Renaming `File.getNode` into `File.get_node` will fix the issue.